### PR TITLE
Enhance HotkeyTooltip and TooltipManager functionality

### DIFF
--- a/src/components/HotkeyTooltip.tsx
+++ b/src/components/HotkeyTooltip.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState, useRef } from 'react';
-import { HotkeyContext, getHotkeysForContext } from '../data/hotkeys';
+import { HotkeyContext, getHotkeysForContext, HotkeyDefinition } from '../data/hotkeys';
 
 interface HotkeyTooltipProps {
   context: HotkeyContext;
   mouseX: number;
   mouseY: number;
   isMouseDown?: boolean;
+  onHotkeyClick?: (hotkey: HotkeyDefinition) => void;
 }
 
 const TOOLTIP_DELAY = 500;
@@ -16,8 +17,8 @@ const styles = {
     backgroundColor: '#1a1a1a',
     border: '1px solid #3d3d3d',
     borderRadius: '6px',
-    padding: '8px 12px',
-    pointerEvents: 'none',
+    padding: '4px',
+    pointerEvents: 'auto',
     zIndex: 10000,
     boxShadow: '0 4px 12px rgba(0, 0, 0, 0.6)',
     maxWidth: '280px',
@@ -26,8 +27,15 @@ const styles = {
     display: 'flex',
     alignItems: 'center',
     gap: '8px',
-    marginBottom: '4px',
+    marginBottom: '0px',
     fontSize: '12px',
+    padding: '6px 8px',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    transition: 'background-color 0.15s ease',
+  } as React.CSSProperties,
+  hotkeyRowHover: {
+    backgroundColor: '#2d2d2d',
   } as React.CSSProperties,
   hotkeyRowLast: {
     marginBottom: '0px',
@@ -47,21 +55,11 @@ const styles = {
   } as React.CSSProperties,
 };
 
-export const HotkeyTooltip: React.FC<HotkeyTooltipProps> = ({ context, mouseX, mouseY, isMouseDown = false }) => {
+export const HotkeyTooltip: React.FC<HotkeyTooltipProps> = ({ context, mouseX, mouseY, isMouseDown = false, onHotkeyClick }) => {
   const [position, setPosition] = useState({ x: mouseX, y: mouseY });
-  const [isVisible, setIsVisible] = useState(false);
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const hotkeys = getHotkeysForContext(context);
-
-  // Handle visibility delay
-  useEffect(() => {
-    setIsVisible(false);
-    const timer = setTimeout(() => {
-      setIsVisible(true);
-    }, TOOLTIP_DELAY);
-
-    return () => clearTimeout(timer);
-  }, [context]);
 
   useEffect(() => {
     // Wait for tooltip to be rendered so we can get its actual dimensions
@@ -88,12 +86,19 @@ export const HotkeyTooltip: React.FC<HotkeyTooltipProps> = ({ context, mouseX, m
     }
 
     setPosition({ x, y });
-  }, [mouseX, mouseY, hotkeys.length, isVisible]);
+  }, [mouseX, mouseY, hotkeys.length]);
 
-  // Hide tooltip when mouse is down (dragging) or during delay
-  if (hotkeys.length === 0 || isMouseDown || !isVisible) {
+  // Hide tooltip when mouse is down (dragging)
+  if (hotkeys.length === 0 || isMouseDown) {
     return null;
   }
+
+  const handleHotkeyClick = (hotkey: HotkeyDefinition, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (onHotkeyClick) {
+      onHotkeyClick(hotkey);
+    }
+  };
 
   return (
     <div
@@ -103,6 +108,7 @@ export const HotkeyTooltip: React.FC<HotkeyTooltipProps> = ({ context, mouseX, m
         left: `${position.x}px`,
         top: `${position.y}px`,
       }}
+      onClick={(e) => e.stopPropagation()}
     >
       {hotkeys.map((hotkey, index) => (
         <div
@@ -110,7 +116,11 @@ export const HotkeyTooltip: React.FC<HotkeyTooltipProps> = ({ context, mouseX, m
           style={{
             ...styles.hotkeyRow,
             ...(index === hotkeys.length - 1 ? styles.hotkeyRowLast : {}),
+            ...(hoveredIndex === index ? styles.hotkeyRowHover : {}),
           }}
+          onMouseEnter={() => setHoveredIndex(index)}
+          onMouseLeave={() => setHoveredIndex(null)}
+          onClick={(e) => handleHotkeyClick(hotkey, e)}
         >
           <span style={styles.hotkeyKey}>{hotkey.key}</span>
           <span style={styles.hotkeyAction}>{hotkey.shortDescription}</span>

--- a/src/modules/whiteboard/KeyboardHandler.ts
+++ b/src/modules/whiteboard/KeyboardHandler.ts
@@ -46,6 +46,57 @@ export class KeyboardHandler {
     return this.hoveredCardId;
   }
 
+  /**
+   * Execute a hotkey action programmatically
+   * @param key - The key to simulate (e.g., 'c', 'Space', 'f', '+  or  =')
+   * @param cardId - Optional card ID to use as context (if null, uses hovered card)
+   */
+  public executeHotkey(key: string, cardId: string | null = null): void {
+    // Normalize key (handle special cases and display strings)
+    let normalizedKey = key.toLowerCase().trim();
+    
+    // Handle display strings from hotkeys.ts
+    if (normalizedKey === 'space') {
+      normalizedKey = ' ';
+    } else if (normalizedKey.includes('+') || normalizedKey.includes('=')) {
+      // Handle '+  or  =' -> use '='
+      normalizedKey = '=';
+    } else if (normalizedKey.includes('-') || normalizedKey.includes('_')) {
+      // Handle '-  or  _' -> use '-'
+      normalizedKey = '-';
+    } else {
+      // For regular keys, use first character (handles 'C' -> 'c')
+      normalizedKey = normalizedKey.charAt(0);
+    }
+
+    // Use provided cardId or fall back to hovered card
+    const targetCardId = cardId ?? this.hoveredCardId;
+    const card = targetCardId ? this.yCards.get(targetCardId) : null;
+
+    // Create a mock keyboard event for compatibility
+    const mockEvent = {
+      key: normalizedKey,
+      preventDefault: () => {},
+      target: document.body,
+    } as KeyboardEvent;
+
+    // Temporarily set hovered card if provided
+    const originalHoveredCard = this.hoveredCardId;
+    if (cardId !== null) {
+      this.hoveredCardId = cardId;
+    }
+
+    try {
+      // Execute the action
+      this.handleKeyDown(mockEvent);
+    } finally {
+      // Restore original hovered card
+      if (cardId !== null) {
+        this.hoveredCardId = originalHoveredCard;
+      }
+    }
+  }
+
   private attachListeners(): void {
     document.addEventListener('keydown', this.handleKeyDownBound);
   }

--- a/src/modules/whiteboard/MultiPlayerBoardManager.ts
+++ b/src/modules/whiteboard/MultiPlayerBoardManager.ts
@@ -28,6 +28,10 @@ export class MultiPlayerBoardManager {
   private localPlayerId: string;
   private backgroundColor: string;
   private tooltipManager: TooltipManager;
+  // Track mouse movement to distinguish clicks from drags
+  private mouseDownPosition: { x: number; y: number; cardId: string } | null = null;
+  private readonly DRAG_THRESHOLD = 5; // pixels
+  private isDragging: boolean = false;
 
   // Opponent opacity state management
   private pinnedOpponentId: string | null = null;
@@ -67,10 +71,6 @@ export class MultiPlayerBoardManager {
     this.attachEventListeners();
     this.setupOpponentHoverListener();
 
-    // Initialize tooltip manager
-    this.tooltipManager = new TooltipManager();
-    this.tooltipManager.setup();
-
     // Initialize keyboard handler with empty callbacks (will be set by app)
     this.keyboardHandler = new KeyboardHandler(
       this.yCards,
@@ -91,6 +91,13 @@ export class MultiPlayerBoardManager {
       },
       this.localPlayerId
     );
+
+    // Initialize tooltip manager with hotkey click handler
+    this.tooltipManager = new TooltipManager();
+    this.tooltipManager.setup((hotkey, cardId) => {
+      // Execute the hotkey action for the specified card
+      this.keyboardHandler.executeHotkey(hotkey.key, cardId);
+    });
   }
 
   public setKeyboardCallbacks(callbacks: KeyboardHandlerCallbacks): void {
@@ -412,14 +419,12 @@ export class MultiPlayerBoardManager {
       cardElement.appendChild(countersContainer);
     }
 
-    // Enable hover for all cards (for card preview and keyboard shortcuts)
+    // Enable hover for card preview (still works on hover)
     cardElement.addEventListener('mouseenter', (e: MouseEvent) => {
       this.keyboardHandler.setHoveredCard(card.id);
       // Get latest card state from Yjs to avoid stale closures
       const latestCard = this.yCards.get(card.id) || card;
       this.cardPreview.show(latestCard);
-      // Trigger hotkey tooltips
-      this.tooltipManager.update(true);
     });
 
     cardElement.addEventListener('mousemove', (e: MouseEvent) => {
@@ -429,11 +434,33 @@ export class MultiPlayerBoardManager {
     cardElement.addEventListener('mouseleave', () => {
       this.keyboardHandler.setHoveredCard(null);
       this.cardPreview.hide();
-      // Hide tooltip when not hovering a card
-      this.tooltipManager.update(false);
     });
 
-    cardElement.addEventListener('mousedown', (e) => this.onMouseDown(e, card.id));
+    // Handle click for tooltip menu (distinguish from drag)
+    cardElement.addEventListener('click', (e: MouseEvent) => {
+      // Only show menu if this was a click (not a drag) and it's the same card
+      if (this.mouseDownPosition && this.mouseDownPosition.cardId === card.id) {
+        const dx = Math.abs(e.clientX - this.mouseDownPosition.x);
+        const dy = Math.abs(e.clientY - this.mouseDownPosition.y);
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        
+        // If mouse moved less than threshold and wasn't dragging, treat as click
+        if (distance < this.DRAG_THRESHOLD && !this.isDragging && card.ownerId === this.localPlayerId) {
+          // Show tooltip menu
+          this.tooltipManager.show(card.id, e.clientX, e.clientY);
+        }
+      }
+      // Always clear drag state after click handler
+      this.mouseDownPosition = null;
+      this.isDragging = false;
+    });
+
+    cardElement.addEventListener('mousedown', (e) => {
+      // Store mouse down position to detect drags
+      this.mouseDownPosition = { x: e.clientX, y: e.clientY, cardId: card.id };
+      this.isDragging = false;
+      this.onMouseDown(e, card.id);
+    });
 
     return cardElement;
   }
@@ -555,6 +582,16 @@ export class MultiPlayerBoardManager {
     const card = this.cards.get(this.dragState.cardId);
     if (!card || card.ownerId !== this.localPlayerId) return;
 
+    // Check if we've moved enough to consider this a drag
+    if (this.mouseDownPosition && !this.isDragging) {
+      const dx = Math.abs(e.clientX - this.mouseDownPosition.x);
+      const dy = Math.abs(e.clientY - this.mouseDownPosition.y);
+      const distance = Math.sqrt(dx * dx + dy * dy);
+      if (distance >= this.DRAG_THRESHOLD) {
+        this.isDragging = true;
+      }
+    }
+
     const x = e.clientX - this.dragState.offsetX;
     const y = e.clientY - this.dragState.offsetY;
 
@@ -583,6 +620,8 @@ export class MultiPlayerBoardManager {
 
             // Clear drag state and return early (card will be removed from battlefield)
             this.dragState = { cardId: null, offsetX: 0, offsetY: 0 };
+            this.mouseDownPosition = null;
+            this.isDragging = false;
             return;
           }
         }
@@ -601,6 +640,14 @@ export class MultiPlayerBoardManager {
     }
 
     this.dragState = { cardId: null, offsetX: 0, offsetY: 0 };
+    
+    // If we were dragging, clear the mouseDownPosition immediately
+    // Otherwise, let the click handler clear it (so it can detect clicks)
+    if (this.isDragging || !this.mouseDownPosition) {
+      this.mouseDownPosition = null;
+      this.isDragging = false;
+    }
+    // If not dragging and mouseDownPosition exists, the click handler will clear it
   }
 
   private attachEventListeners(): void {

--- a/src/modules/whiteboard/TooltipManager.ts
+++ b/src/modules/whiteboard/TooltipManager.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createRoot, Root } from 'react-dom/client';
 import { HotkeyTooltip } from '../../components';
-import { HotkeyContext } from '../../data/hotkeys';
+import { HotkeyContext, HotkeyDefinition } from '../../data/hotkeys';
 
 /**
  * Manages hotkey tooltip display for the battlefield
@@ -12,16 +12,20 @@ export class TooltipManager {
   private currentMouseX: number = 0;
   private currentMouseY: number = 0;
   private mouseMoveHandler: ((e: MouseEvent) => void) | null = null;
+  private clickedCardId: string | null = null;
+  private clickPosition: { x: number; y: number } | null = null;
+  private onHotkeyClick: ((hotkey: HotkeyDefinition, cardId: string) => void) | null = null;
 
   /**
    * Initialize tooltip container and event listeners
    */
-  setup(): void {
+  setup(onHotkeyClick?: (hotkey: HotkeyDefinition, cardId: string) => void): void {
     // Create tooltip container
     this.tooltipContainer = document.createElement('div');
     this.tooltipContainer.className = 'hotkey-tooltip-container-battlefield';
     document.body.appendChild(this.tooltipContainer);
     this.tooltipRoot = createRoot(this.tooltipContainer);
+    this.onHotkeyClick = onHotkeyClick || null;
 
     // Setup mouse move listener to track cursor position
     this.mouseMoveHandler = (e: MouseEvent) => {
@@ -29,26 +33,93 @@ export class TooltipManager {
       this.currentMouseY = e.clientY;
     };
     document.addEventListener('mousemove', this.mouseMoveHandler);
+
+    // Setup click outside handler
+    document.addEventListener('click', this.handleClickOutside.bind(this), true);
   }
 
   /**
-   * Update tooltip display based on hover state
-   * @param isCardHovered - Whether a battlefield card is currently hovered
+   * Handle clicks outside the tooltip to close it
    */
-  update(isCardHovered: boolean): void {
+  private handleClickOutside(e: MouseEvent): void {
+    if (!this.clickedCardId || !this.tooltipContainer) return;
+
+    const target = e.target as HTMLElement;
+    // Check if click is outside the tooltip container
+    if (!this.tooltipContainer.contains(target)) {
+      // Check if click is on the card that opened the menu
+      // If so, don't handle it here - let the card's click handler handle it (for toggle behavior)
+      const cardElement = target.closest('[data-card-id]');
+      if (cardElement && cardElement.getAttribute('data-card-id') === this.clickedCardId) {
+        // Don't handle clicks on the card itself - card click handler will handle toggle
+        return;
+      }
+      // Hide menu if clicking anywhere else (outside both tooltip and card)
+      this.hide();
+    }
+  }
+
+  /**
+   * Show tooltip for a clicked card
+   * @param cardId - The ID of the card that was clicked
+   * @param clickX - X position of the click
+   * @param clickY - Y position of the click
+   */
+  show(cardId: string, clickX: number, clickY: number): void {
     if (!this.tooltipRoot) return;
 
-    if (isCardHovered) {
-      this.tooltipRoot.render(
-        React.createElement(HotkeyTooltip, {
-          context: 'battlefield' as HotkeyContext,
-          mouseX: this.currentMouseX,
-          mouseY: this.currentMouseY,
-        })
-      );
-    } else {
-      this.tooltipRoot.render(null);
+    // Toggle: if same card is clicked, hide it
+    if (this.clickedCardId === cardId) {
+      this.hide();
+      return;
     }
+
+    this.clickedCardId = cardId;
+    this.clickPosition = { x: clickX, y: clickY };
+    this.currentMouseX = clickX;
+    this.currentMouseY = clickY;
+
+    this.tooltipRoot.render(
+      React.createElement(HotkeyTooltip, {
+        context: 'battlefield' as HotkeyContext,
+        mouseX: clickX,
+        mouseY: clickY,
+        onHotkeyClick: (hotkey: HotkeyDefinition) => {
+          if (this.onHotkeyClick && this.clickedCardId) {
+            this.onHotkeyClick(hotkey, this.clickedCardId);
+          }
+          // Hide menu after clicking an item
+          this.hide();
+        },
+      })
+    );
+  }
+
+  /**
+   * Hide tooltip
+   */
+  hide(): void {
+    if (!this.tooltipRoot) return;
+    this.clickedCardId = null;
+    this.clickPosition = null;
+    this.tooltipRoot.render(null);
+  }
+
+  /**
+   * Check if tooltip is currently showing for a card
+   */
+  isShowingForCard(cardId: string): boolean {
+    return this.clickedCardId === cardId;
+  }
+
+  /**
+   * Update tooltip display based on hover state (kept for backward compatibility, but deprecated)
+   * @param isCardHovered - Whether a battlefield card is currently hovered
+   * @deprecated Use show() and hide() instead
+   */
+  update(isCardHovered: boolean): void {
+    // This method is kept for backward compatibility but does nothing
+    // The new click-based system uses show() and hide() instead
   }
 
   /**
@@ -67,5 +138,6 @@ export class TooltipManager {
       document.removeEventListener('mousemove', this.mouseMoveHandler);
       this.mouseMoveHandler = null;
     }
+    document.removeEventListener('click', this.handleClickOutside.bind(this), true);
   }
 }


### PR DESCRIPTION
Turned the hotkey tooltip into a clickable menu. Actions are now executable by hotkey or clicking. Details below.

- Added onHotkeyClick prop to HotkeyTooltip for handling hotkey actions.
- Added hover effects to card menu.
- Implemented executeHotkey method in KeyboardHandler for programmatic hotkey execution.
- Updated TooltipManager to manage tooltip visibility and interactions based on clicks.
- Enhanced MultiPlayerBoardManager to support tooltip display on card clicks while distinguishing between clicks and drags.

<img width="247" height="391" alt="image" src="https://github.com/user-attachments/assets/fde03f12-b550-4a3e-90bb-5d1832de9135" />

TODO: make this work on cards in dock as well. 