### PR TITLE
Ignore modifier keys on key press

### DIFF
--- a/src/modules/whiteboard/KeyboardHandler.ts
+++ b/src/modules/whiteboard/KeyboardHandler.ts
@@ -102,6 +102,9 @@ export class KeyboardHandler {
   }
 
   private handleKeyDown(e: KeyboardEvent): void {
+    // Ignore if modifier keys are held
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
+    
     // Ignore if typing in an input
     if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
       return;


### PR DESCRIPTION
This PR ignores keypresses when the `ctrl`, `meta`, or `alt` keys are held down. This allows the browser's zoom functionality to remain in place while hotkey-presses should remain unaffected.