### PR TITLE
feat: don't create duplicate counters & +/- counter cancel logic

### DIFF
--- a/src/modules/whiteboard/KeyboardHandler.ts
+++ b/src/modules/whiteboard/KeyboardHandler.ts
@@ -58,7 +58,7 @@ export class KeyboardHandler {
   public executeHotkey(key: string, cardId: string | null = null): void {
     // Normalize key (handle special cases and display strings)
     let normalizedKey = key.toLowerCase().trim();
-    
+
     // Handle display strings from hotkeys.ts
     if (normalizedKey === 'space') {
       normalizedKey = ' ';
@@ -109,7 +109,7 @@ export class KeyboardHandler {
   private handleKeyDown(e: KeyboardEvent): void {
     // Ignore if modifier keys are held
     if (e.ctrlKey || e.metaKey || e.altKey) return;
-    
+
     // Ignore if typing in an input
     if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
       return;
@@ -140,14 +140,14 @@ export class KeyboardHandler {
     }
 
     // lose health / subtract health
-    if (key === '-' || key === '_' ) {
+    if (key === '-' || key === '_') {
       e.preventDefault();
       this.callbacks.loseHealth();
       return;
     }
 
     // gain health / add health
-    if (key === '=' || key === '+' ) {
+    if (key === '=' || key === '+') {
       e.preventDefault();
       this.callbacks.gainHealth();
       return;
@@ -391,13 +391,23 @@ export class KeyboardHandler {
   }
 
   private addPositiveCounter(card: WhiteboardCard): void {
-    const updatedCard = { ...card, counters: [...card.counters, 1] };
-    this.yCards.set(card.id, updatedCard);
+    this.adjustCounters(card, 1);
   }
 
   private addNegativeCounter(card: WhiteboardCard): void {
-    const updatedCard = { ...card, counters: [...card.counters, -1] };
-    this.yCards.set(card.id, updatedCard);
+    this.adjustCounters(card, -1);
+  }
+
+  /**
+   * This method calculates the net counters on a card and updates the Y.Map with the new counters array.
+   * Positive and negative counters cancel each other out, so we sum them to get the net effect. 
+   * @param card 
+   * @param delta 
+   */
+  private adjustCounters(card: WhiteboardCard, delta: number): void {
+    const net = card.counters.reduce((sum, c) => sum + c, 0) + delta;
+    const counters = Array.from({ length: Math.abs(net) }, () => Math.sign(net));
+    this.yCards.set(card.id, { ...card, counters });
   }
 
   private removeCard(cardId: string): void {
@@ -409,7 +419,7 @@ export class KeyboardHandler {
 
     // Reset multiplier if copying a different card OR if enough time passed
     if (this.lastCopiedCardId !== card.id ||
-        now - this.lastCopyTime > this.COPY_RESET_DELAY) {
+      now - this.lastCopyTime > this.COPY_RESET_DELAY) {
       this.copyOffsetMultiplier = 0;
     }
 

--- a/src/modules/whiteboard/MultiPlayerBoardManager.ts
+++ b/src/modules/whiteboard/MultiPlayerBoardManager.ts
@@ -342,13 +342,11 @@ export class MultiPlayerBoardManager {
         existingCounters.remove();
       }
 
-      if (card.counters && card.counters.length > 0) {
+      const net = (card.counters ?? []).reduce((s, c) => s + c, 0);
+      if (net !== 0) {
         const countersContainer = document.createElement('div');
         countersContainer.className = 'card-counters';
-        card.counters.forEach((counterValue, index) => {
-          const counter = this.createCounterElement(card, index, counterValue);
-          countersContainer.appendChild(counter);
-        });
+        countersContainer.appendChild(this.createCounterElement(card, 0, net));
         cardElement.appendChild(countersContainer);
       }
     }
@@ -414,14 +412,12 @@ export class MultiPlayerBoardManager {
       cardElement.appendChild(badge);
     }
 
-    // Add counters container
-    if (card.counters && card.counters.length > 0) {
+    // Add counters container (single badge showing net + / - total)
+    const counterNet = (card.counters ?? []).reduce((s, c) => s + c, 0);
+    if (counterNet !== 0) {
       const countersContainer = document.createElement('div');
       countersContainer.className = 'card-counters';
-      card.counters.forEach((counterValue, index) => {
-        const counter = this.createCounterElement(card, index, counterValue);
-        countersContainer.appendChild(counter);
-      });
+      countersContainer.appendChild(this.createCounterElement(card, 0, counterNet));
       cardElement.appendChild(countersContainer);
     }
 
@@ -501,21 +497,15 @@ export class MultiPlayerBoardManager {
     return counterContainer;
   }
 
-  private modifyCounter(cardId: string, index: number, delta: number): void {
+  private modifyCounter(cardId: string, _index: number, delta: number): void {
     // Get the latest card from Yjs to avoid stale closures
     const card = this.yCards.get(cardId);
     if (!card) return;
 
-    const updatedCounters = [...card.counters];
-    updatedCounters[index] = updatedCounters[index] + delta;
-
-    // Remove counter if it reaches 0
-    if (updatedCounters[index] === 0) {
-      updatedCounters.splice(index, 1);
-    }
-
-    const updatedCard = { ...card, counters: updatedCounters };
-    this.yCards.set(cardId, updatedCard);
+    // + and - cancel out; card holds a single net value (one sign).
+    const net = (card.counters ?? []).reduce((s: number, c: number) => s + c, 0) + delta;
+    const counters = Array.from({ length: Math.abs(net) }, () => Math.sign(net));
+    this.yCards.set(cardId, { ...card, counters });
   }
 
   private updateCardPosition(element: HTMLElement, card: WhiteboardCard): void {


### PR DESCRIPTION
### Description

- don't allow multiple `+/-` counters on the same card e.g. 2 `+` counters will render separate inputs
- `+` and `-` counters cancel each other out

---

https://github.com/user-attachments/assets/0e8812d4-a8a5-46b4-a3a5-f213f8069276



